### PR TITLE
Properly handle deleted remote resources

### DIFF
--- a/docs/resources/appointment_template.md
+++ b/docs/resources/appointment_template.md
@@ -55,6 +55,7 @@ Optional:
 - `ephemeral` (Boolean) if true, the value of the input will not be persisted
 - `items` (List of String) only used when the type is select or multi select. This is a list of values that the user can choose from
 - `placeholder` (Map of String) a map of values, where the key and values are strings
+- `propagate_changes` (Boolean) if true, changes to the input will be propagated to event listeners for the custom form
 - `required` (Boolean) if true, the user will be required to provide a value
 - `target` (String) the attribute name to use when exporting the result of this input
 - `view_label` (Map of String) a map of values, where the key and values are strings

--- a/internal/provider/appointment_schedule_resource.go
+++ b/internal/provider/appointment_schedule_resource.go
@@ -141,8 +141,11 @@ func (r *AppointmentSchedule) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	newApp, _, err := r.client.GetApi().GetAppointmentSchedule(ctx, state.ID.ValueString()).Execute()
-	if err != nil {
+	newApp, httpResp, err := r.client.GetApi().GetAppointmentSchedule(ctx, state.ID.ValueString()).Execute()
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Appointment Schedule",
 			fmt.Sprintf("Could not read entity in Udoma, unexpected error: %s", getApiErrorMessage(err)),

--- a/internal/provider/appointment_template_resource.go
+++ b/internal/provider/appointment_template_resource.go
@@ -131,8 +131,11 @@ func (r *AppointmentTemplate) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	newTemplate, _, err := r.client.GetApi().GetAppointmentTemplate(ctx, state.ID.ValueString()).Execute()
-	if err != nil {
+	newTemplate, httpResp, err := r.client.GetApi().GetAppointmentTemplate(ctx, state.ID.ValueString()).Execute()
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Appointment Schedule",
 			fmt.Sprintf("Could not read entity in Udoma, unexpected error: %s", getApiErrorMessage(err)),

--- a/internal/provider/case_reporting_endpoint_resource.go
+++ b/internal/provider/case_reporting_endpoint_resource.go
@@ -173,8 +173,11 @@ func (r *CaseReportingEndpoint) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	endpoint, _, err := r.client.GetApi().GetCaseReportingEndpoint(ctx, state.Code.ValueString()).Execute()
-	if err != nil {
+	endpoint, httpResp, err := r.client.GetApi().GetCaseReportingEndpoint(ctx, state.Code.ValueString()).Execute()
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Case Reporting Endpoint",
 			"Could not read entity from Udoma, unexpected error: "+err.Error(),

--- a/internal/provider/case_template_resource.go
+++ b/internal/provider/case_template_resource.go
@@ -196,8 +196,11 @@ func (r *caseTemplate) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	template, _, err := r.client.GetApi().GetCaseTemplate(ctx, state.ID.ValueString()).Execute()
-	if err != nil {
+	template, httpResp, err := r.client.GetApi().GetCaseTemplate(ctx, state.ID.ValueString()).Execute()
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Case Template",
 			"Could not read entity from Udoma, unexpected error: "+getApiErrorMessage(err),

--- a/internal/provider/custom_form.go
+++ b/internal/provider/custom_form.go
@@ -52,17 +52,18 @@ func NewCustomFormInputNull() CustomFormInputModel {
 }
 
 type CustomFormInputModel struct {
-	ID           types.String `tfsdk:"id"`
-	Label        types.Map    `tfsdk:"label"`
-	ViewLabel    types.Map    `tfsdk:"view_label"`
-	Placeholder  types.Map    `tfsdk:"placeholder"`
-	Type         types.String `tfsdk:"type"`
-	DefaultValue types.String `tfsdk:"default_value"`
-	Required     types.Bool   `tfsdk:"required"`
-	Ephemeral    types.Bool   `tfsdk:"ephemeral"`
-	Target       types.String `tfsdk:"target"`
-	Attributes   types.Map    `tfsdk:"attributes"`
-	Items        types.List   `tfsdk:"items"`
+	ID               types.String `tfsdk:"id"`
+	Label            types.Map    `tfsdk:"label"`
+	ViewLabel        types.Map    `tfsdk:"view_label"`
+	Placeholder      types.Map    `tfsdk:"placeholder"`
+	Type             types.String `tfsdk:"type"`
+	DefaultValue     types.String `tfsdk:"default_value"`
+	Required         types.Bool   `tfsdk:"required"`
+	Ephemeral        types.Bool   `tfsdk:"ephemeral"`
+	PropagateChanges types.Bool   `tfsdk:"propagate_changes"`
+	Target           types.String `tfsdk:"target"`
+	Attributes       types.Map    `tfsdk:"attributes"`
+	Items            types.List   `tfsdk:"items"`
 }
 
 func NewCustomFormValidationNull() CustomFormValidationModel {

--- a/internal/provider/custom_form.go
+++ b/internal/provider/custom_form.go
@@ -431,17 +431,18 @@ func (input *CustomFormInputModel) toApiRequest() *v1.FormInput {
 	inputType := v1.FormInputType(input.Type.ValueString())
 
 	return &v1.FormInput{
-		Id:           input.ID.ValueStringPointer(),
-		Label:        modelMapToStringMap(input.Label),
-		ViewLabel:    modelMapToStringMap(input.ViewLabel),
-		Placeholder:  modelMapToStringMap(input.Placeholder),
-		Type:         &inputType,
-		DefaultValue: input.DefaultValue.ValueStringPointer(),
-		Required:     input.Required.ValueBoolPointer(),
-		Ephemeral:    input.Ephemeral.ValueBoolPointer(),
-		Target:       input.Target.ValueStringPointer(),
-		Attributes:   modelMapToStringMap(input.Attributes),
-		Items:        modelListToStringSlice(input.Items),
+		Id:               input.ID.ValueStringPointer(),
+		Label:            modelMapToStringMap(input.Label),
+		ViewLabel:        modelMapToStringMap(input.ViewLabel),
+		Placeholder:      modelMapToStringMap(input.Placeholder),
+		Type:             &inputType,
+		DefaultValue:     input.DefaultValue.ValueStringPointer(),
+		Required:         input.Required.ValueBoolPointer(),
+		PropagateChanges: input.PropagateChanges.ValueBoolPointer(),
+		Ephemeral:        input.Ephemeral.ValueBoolPointer(),
+		Target:           input.Target.ValueStringPointer(),
+		Attributes:       modelMapToStringMap(input.Attributes),
+		Items:            modelListToStringSlice(input.Items),
 	}
 }
 
@@ -481,11 +482,14 @@ func (input *CustomFormInputModel) fromApiResponse(resp *v1.FormInput) (diags di
 	if resp.Required != nil {
 		input.Required = types.BoolValue(*resp.Required)
 	}
+	if resp.PropagateChanges != nil {
+		input.PropagateChanges = types.BoolValue(*resp.PropagateChanges)
+	}
 	if resp.Ephemeral != nil {
-		input.Ephemeral = types.BoolValue(bdp(resp.Ephemeral))
+		input.Ephemeral = types.BoolValue(*resp.Ephemeral)
 	}
 	if resp.Target != nil {
-		input.Target = types.StringValue(sdp(resp.Target))
+		input.Target = types.StringValue(*resp.Target)
 	}
 
 	if resp.Attributes != nil {

--- a/internal/provider/custom_id_generator_resource.go
+++ b/internal/provider/custom_id_generator_resource.go
@@ -163,8 +163,11 @@ func (r *customIDGenerator) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	generator, _, err := r.client.GetApi().GetCustomIDGenerator(ctx, state.ID.ValueString()).Execute()
-	if err != nil {
+	generator, httpResp, err := r.client.GetApi().GetCustomIDGenerator(ctx, state.ID.ValueString()).Execute()
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Custom ID Generator",
 			"Could not read entity from Udoma, unexpected error: "+getApiErrorMessage(err),

--- a/internal/provider/customer_script_resource.go
+++ b/internal/provider/customer_script_resource.go
@@ -161,8 +161,11 @@ func (r *customerScript) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	script, _, err := r.client.GetApi().GetCustomerScript(ctx, state.ID.ValueString()).Execute()
-	if err != nil {
+	script, httpResp, err := r.client.GetApi().GetCustomerScript(ctx, state.ID.ValueString()).Execute()
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Customer Script",
 			"Could not read entity from Udoma, unexpected error: "+getApiErrorMessage(err),

--- a/internal/provider/document_template_resource.go
+++ b/internal/provider/document_template_resource.go
@@ -205,8 +205,11 @@ func (r *documentTemplate) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	template, _, err := r.client.GetApi().GetDocumentTemplate(ctx, state.ID.ValueString()).Execute()
-	if err != nil {
+	template, httpResp, err := r.client.GetApi().GetDocumentTemplate(ctx, state.ID.ValueString()).Execute()
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Document Template",
 			"Could not read entity from Udoma, unexpected error: "+getApiErrorMessage(err),

--- a/internal/provider/workflow_entrypoint_resource.go
+++ b/internal/provider/workflow_entrypoint_resource.go
@@ -182,8 +182,11 @@ func (r *workflowEntrypoint) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	workflow, _, err := r.client.GetApi().GetWorkflowEntrypoint(ctx, state.ID.ValueString()).Execute()
-	if err != nil {
+	workflow, httpResp, err := r.client.GetApi().GetWorkflowEntrypoint(ctx, state.ID.ValueString()).Execute()
+	if httpResp != nil && httpResp.StatusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Workflow Entrypoint",
 			"Could not read entity from Udoma, unexpected error: "+getApiErrorMessage(err),


### PR DESCRIPTION
Fixed all `read` operations to properly handle the case, where a resource that is in the state is no longer present on the remote system. 

Additionally added some fixes to custom forms that were missed during the respective PR. 