### PR TITLE
Fixed the name of the display_condition attribute in custom forms

### DIFF
--- a/docs/resources/appointment_template.md
+++ b/docs/resources/appointment_template.md
@@ -69,8 +69,8 @@ Required:
 Optional:
 
 - `attributes` (Map of String) a map of values, where the key and values are strings
-- `condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--inputs--inputs--condition))
 - `default_value` (String) optional default value for the input field (as a JSON string)
+- `display_condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--inputs--inputs--display_condition))
 - `ephemeral` (Boolean) if true, the value of the input will not be persisted
 - `items` (Attributes List) Only used when the type is select or multi select. This is a list of values that the user can choose from. (see [below for nested schema](#nestedatt--inputs--inputs--items))
 - `label` (Map of String) a map of values, where the key and values are strings
@@ -81,8 +81,8 @@ Optional:
 - `target` (String) the attribute name to use when exporting the result of this input
 - `view_label` (Map of String) a map of values, where the key and values are strings
 
-<a id="nestedatt--inputs--inputs--condition"></a>
-### Nested Schema for `inputs.inputs.condition`
+<a id="nestedatt--inputs--inputs--display_condition"></a>
+### Nested Schema for `inputs.inputs.display_condition`
 
 Required:
 

--- a/docs/resources/case_template.md
+++ b/docs/resources/case_template.md
@@ -135,8 +135,8 @@ Required:
 Optional:
 
 - `attributes` (Map of String) a map of values, where the key and values are strings
-- `condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--config--status_config--feedback--form--inputs--condition))
 - `default_value` (String) optional default value for the input field (as a JSON string)
+- `display_condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--config--status_config--feedback--form--inputs--display_condition))
 - `ephemeral` (Boolean) if true, the value of the input will not be persisted
 - `items` (Attributes List) Only used when the type is select or multi select. This is a list of values that the user can choose from. (see [below for nested schema](#nestedatt--config--status_config--feedback--form--inputs--items))
 - `label` (Map of String) a map of values, where the key and values are strings
@@ -147,8 +147,8 @@ Optional:
 - `target` (String) the attribute name to use when exporting the result of this input
 - `view_label` (Map of String) a map of values, where the key and values are strings
 
-<a id="nestedatt--config--status_config--feedback--form--inputs--condition"></a>
-### Nested Schema for `config.status_config.feedback.form.inputs.condition`
+<a id="nestedatt--config--status_config--feedback--form--inputs--display_condition"></a>
+### Nested Schema for `config.status_config.feedback.form.inputs.display_condition`
 
 Required:
 

--- a/docs/resources/form.md
+++ b/docs/resources/form.md
@@ -53,8 +53,8 @@ Required:
 Optional:
 
 - `attributes` (Map of String) a map of values, where the key and values are strings
-- `condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--form_definition--inputs--condition))
 - `default_value` (String) optional default value for the input field (as a JSON string)
+- `display_condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--form_definition--inputs--display_condition))
 - `ephemeral` (Boolean) if true, the value of the input will not be persisted
 - `items` (Attributes List) Only used when the type is select or multi select. This is a list of values that the user can choose from. (see [below for nested schema](#nestedatt--form_definition--inputs--items))
 - `label` (Map of String) a map of values, where the key and values are strings
@@ -65,8 +65,8 @@ Optional:
 - `target` (String) the attribute name to use when exporting the result of this input
 - `view_label` (Map of String) a map of values, where the key and values are strings
 
-<a id="nestedatt--form_definition--inputs--condition"></a>
-### Nested Schema for `form_definition.inputs.condition`
+<a id="nestedatt--form_definition--inputs--display_condition"></a>
+### Nested Schema for `form_definition.inputs.display_condition`
 
 Required:
 

--- a/docs/resources/property_handover_template.md
+++ b/docs/resources/property_handover_template.md
@@ -53,8 +53,8 @@ Required:
 Optional:
 
 - `attributes` (Map of String) a map of values, where the key and values are strings
-- `condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--inputs--inputs--condition))
 - `default_value` (String) optional default value for the input field (as a JSON string)
+- `display_condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--inputs--inputs--display_condition))
 - `ephemeral` (Boolean) if true, the value of the input will not be persisted
 - `items` (Attributes List) Only used when the type is select or multi select. This is a list of values that the user can choose from. (see [below for nested schema](#nestedatt--inputs--inputs--items))
 - `label` (Map of String) a map of values, where the key and values are strings
@@ -65,8 +65,8 @@ Optional:
 - `target` (String) the attribute name to use when exporting the result of this input
 - `view_label` (Map of String) a map of values, where the key and values are strings
 
-<a id="nestedatt--inputs--inputs--condition"></a>
-### Nested Schema for `inputs.inputs.condition`
+<a id="nestedatt--inputs--inputs--display_condition"></a>
+### Nested Schema for `inputs.inputs.display_condition`
 
 Required:
 

--- a/docs/resources/report_definition.md
+++ b/docs/resources/report_definition.md
@@ -85,8 +85,8 @@ Required:
 Optional:
 
 - `attributes` (Map of String) a map of values, where the key and values are strings
-- `condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--parameters--inputs--condition))
 - `default_value` (String) optional default value for the input field (as a JSON string)
+- `display_condition` (Attributes) Optional condition that must be met for the input to be displayed (see [below for nested schema](#nestedatt--parameters--inputs--display_condition))
 - `ephemeral` (Boolean) if true, the value of the input will not be persisted
 - `items` (Attributes List) Only used when the type is select or multi select. This is a list of values that the user can choose from. (see [below for nested schema](#nestedatt--parameters--inputs--items))
 - `label` (Map of String) a map of values, where the key and values are strings
@@ -97,8 +97,8 @@ Optional:
 - `target` (String) the attribute name to use when exporting the result of this input
 - `view_label` (Map of String) a map of values, where the key and values are strings
 
-<a id="nestedatt--parameters--inputs--condition"></a>
-### Nested Schema for `parameters.inputs.condition`
+<a id="nestedatt--parameters--inputs--display_condition"></a>
+### Nested Schema for `parameters.inputs.display_condition`
 
 Required:
 

--- a/internal/provider/custom_form.go
+++ b/internal/provider/custom_form.go
@@ -86,7 +86,7 @@ type CustomFormInputModel struct {
 	Target           types.String               `tfsdk:"target"`
 	Attributes       types.Map                  `tfsdk:"attributes"`
 	Items            []CustomFormInputItemModel `tfsdk:"items"`
-	DisplayCondition *DisplayConditionModel     `tfsdk:"condition"`
+	DisplayCondition *DisplayConditionModel     `tfsdk:"display_condition"`
 }
 
 func NewCustomFormValidationNull() CustomFormValidationModel {
@@ -275,7 +275,7 @@ func customFormInputNestedSchema() schema.NestedAttributeObject {
 				NestedObject: customFormInputItemNestedSchema(),
 				Description:  "Only used when the type is select or multi select. This is a list of values that the user can choose from.",
 			},
-			"condition": schema.SingleNestedAttribute{
+			"display_condition": schema.SingleNestedAttribute{
 				Optional:    true,
 				Attributes:  conditionalInputNestedSchema(),
 				Description: "Optional condition that must be met for the input to be displayed",
@@ -612,6 +612,9 @@ func (input *CustomFormInputModel) fromApiResponse(resp *v1.FormInput) (diags di
 	}
 
 	if resp.DisplayCondition.IsSet() {
+		if input.DisplayCondition == nil {
+			input.DisplayCondition = &DisplayConditionModel{}
+		}
 		diags = input.DisplayCondition.fromApiResponse(resp.DisplayCondition.Get())
 	}
 


### PR DESCRIPTION
Renamed the `condition` attribute to `display_condition` in custom form inputs