### PR TITLE
Added support for subtitle in custom form groups

### DIFF
--- a/api/v1/model_form_group.go
+++ b/api/v1/model_form_group.go
@@ -26,6 +26,8 @@ type FormGroup struct {
 	Type FormGroupType `json:"type"`
 	// a map of values, where the key and values are strings
 	Label *map[string]string `json:"label,omitempty"`
+	// Optional subtitle for repeat groups. This will be computed dynamically based on the data  provided by the user and will be displayed as a subtitle in the group accordeon. The values are interpreted as JSON paths based on the data for the group.
+	Subtitle []string `json:"subtitle,omitempty"`
 	// a map of values, where the key and values are strings
 	Info *map[string]string `json:"info,omitempty"`
 	// If true, the group will be displayed in a nested UI (only works on mobile and tablet). This  is useful for more complex group that require more space to be displayed. The group will be  displayed in a separate screen, and the user will be able to navigate back and forth between  the group and the main form.
@@ -144,6 +146,38 @@ func (o *FormGroup) HasLabel() bool {
 // SetLabel gets a reference to the given map[string]string and assigns it to the Label field.
 func (o *FormGroup) SetLabel(v map[string]string) {
 	o.Label = &v
+}
+
+// GetSubtitle returns the Subtitle field value if set, zero value otherwise.
+func (o *FormGroup) GetSubtitle() []string {
+	if o == nil || IsNil(o.Subtitle) {
+		var ret []string
+		return ret
+	}
+	return o.Subtitle
+}
+
+// GetSubtitleOk returns a tuple with the Subtitle field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *FormGroup) GetSubtitleOk() ([]string, bool) {
+	if o == nil || IsNil(o.Subtitle) {
+		return nil, false
+	}
+	return o.Subtitle, true
+}
+
+// HasSubtitle returns a boolean if a field has been set.
+func (o *FormGroup) HasSubtitle() bool {
+	if o != nil && !IsNil(o.Subtitle) {
+		return true
+	}
+
+	return false
+}
+
+// SetSubtitle gets a reference to the given []string and assigns it to the Subtitle field.
+func (o *FormGroup) SetSubtitle(v []string) {
+	o.Subtitle = v
 }
 
 // GetInfo returns the Info field value if set, zero value otherwise.
@@ -408,6 +442,9 @@ func (o FormGroup) ToMap() (map[string]interface{}, error) {
 	toSerialize["type"] = o.Type
 	if !IsNil(o.Label) {
 		toSerialize["label"] = o.Label
+	}
+	if !IsNil(o.Subtitle) {
+		toSerialize["subtitle"] = o.Subtitle
 	}
 	if !IsNil(o.Info) {
 		toSerialize["info"] = o.Info

--- a/docs/resources/appointment_template.md
+++ b/docs/resources/appointment_template.md
@@ -128,6 +128,7 @@ Optional:
 - `label` (Map of String) The label of the group
 - `min_size` (Number) the minimum number of items that must be submitted in the group (only used for repeat groups)
 - `nested_display` (Boolean) If true, the nested group will be displayed in a nested UI (only works on mobile and tablet). This is useful for more complex group that require more space to be displayed. The group will be displayed in a separate screen, and the user will be able to navigate back and forth between the group and the main form.
+- `subtitle` (List of String) Optional subtitle for repeat groups. This will be computed dynamically based on the data provided by the user and will be displayed as a subtitle in the group accordeon. The values are interpreted as JSON paths based on the data for the group.
 - `target` (String) the attribute name to use when exporting the result of this group (only used for repeat groups)
 - `top_divider` (Boolean) if true, a divider will be displayed above the group
 

--- a/docs/resources/case_template.md
+++ b/docs/resources/case_template.md
@@ -194,6 +194,7 @@ Optional:
 - `label` (Map of String) The label of the group
 - `min_size` (Number) the minimum number of items that must be submitted in the group (only used for repeat groups)
 - `nested_display` (Boolean) If true, the nested group will be displayed in a nested UI (only works on mobile and tablet). This is useful for more complex group that require more space to be displayed. The group will be displayed in a separate screen, and the user will be able to navigate back and forth between the group and the main form.
+- `subtitle` (List of String) Optional subtitle for repeat groups. This will be computed dynamically based on the data provided by the user and will be displayed as a subtitle in the group accordeon. The values are interpreted as JSON paths based on the data for the group.
 - `target` (String) the attribute name to use when exporting the result of this group (only used for repeat groups)
 - `top_divider` (Boolean) if true, a divider will be displayed above the group
 

--- a/docs/resources/form.md
+++ b/docs/resources/form.md
@@ -112,6 +112,7 @@ Optional:
 - `label` (Map of String) The label of the group
 - `min_size` (Number) the minimum number of items that must be submitted in the group (only used for repeat groups)
 - `nested_display` (Boolean) If true, the nested group will be displayed in a nested UI (only works on mobile and tablet). This is useful for more complex group that require more space to be displayed. The group will be displayed in a separate screen, and the user will be able to navigate back and forth between the group and the main form.
+- `subtitle` (List of String) Optional subtitle for repeat groups. This will be computed dynamically based on the data provided by the user and will be displayed as a subtitle in the group accordeon. The values are interpreted as JSON paths based on the data for the group.
 - `target` (String) the attribute name to use when exporting the result of this group (only used for repeat groups)
 - `top_divider` (Boolean) if true, a divider will be displayed above the group
 

--- a/docs/resources/property_handover_template.md
+++ b/docs/resources/property_handover_template.md
@@ -112,6 +112,7 @@ Optional:
 - `label` (Map of String) The label of the group
 - `min_size` (Number) the minimum number of items that must be submitted in the group (only used for repeat groups)
 - `nested_display` (Boolean) If true, the nested group will be displayed in a nested UI (only works on mobile and tablet). This is useful for more complex group that require more space to be displayed. The group will be displayed in a separate screen, and the user will be able to navigate back and forth between the group and the main form.
+- `subtitle` (List of String) Optional subtitle for repeat groups. This will be computed dynamically based on the data provided by the user and will be displayed as a subtitle in the group accordeon. The values are interpreted as JSON paths based on the data for the group.
 - `target` (String) the attribute name to use when exporting the result of this group (only used for repeat groups)
 - `top_divider` (Boolean) if true, a divider will be displayed above the group
 

--- a/docs/resources/report_definition.md
+++ b/docs/resources/report_definition.md
@@ -144,6 +144,7 @@ Optional:
 - `label` (Map of String) The label of the group
 - `min_size` (Number) the minimum number of items that must be submitted in the group (only used for repeat groups)
 - `nested_display` (Boolean) If true, the nested group will be displayed in a nested UI (only works on mobile and tablet). This is useful for more complex group that require more space to be displayed. The group will be displayed in a separate screen, and the user will be able to navigate back and forth between the group and the main form.
+- `subtitle` (List of String) Optional subtitle for repeat groups. This will be computed dynamically based on the data provided by the user and will be displayed as a subtitle in the group accordeon. The values are interpreted as JSON paths based on the data for the group.
 - `target` (String) the attribute name to use when exporting the result of this group (only used for repeat groups)
 - `top_divider` (Boolean) if true, a divider will be displayed above the group
 

--- a/internal/provider/custom_form.go
+++ b/internal/provider/custom_form.go
@@ -33,6 +33,7 @@ type CustomFormGroupModel struct {
 	Type          types.String          `tfsdk:"type"`
 	Label         types.Map             `tfsdk:"label"`
 	Info          types.Map             `tfsdk:"info"`
+	Subtitle      types.List            `tfsdk:"subtitle"`
 	NestedDisplay types.Bool            `tfsdk:"nested_display"`
 	Items         []CustomFormItemModel `tfsdk:"items"`
 	Target        types.String          `tfsdk:"target"`
@@ -159,6 +160,13 @@ func customFormGroupNestedSchema() schema.NestedAttributeObject {
 				Optional:    true,
 				ElementType: types.StringType,
 				Description: "The label of the group",
+			},
+			"subtitle": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Optional subtitle for repeat groups. This will be computed dynamically based on the " +
+					"data provided by the user and will be displayed as a subtitle in the group accordeon. The " +
+					"values are interpreted as JSON paths based on the data for the group.",
 			},
 			"info": schema.MapAttribute{
 				Optional:    true,
@@ -449,6 +457,7 @@ func (group *CustomFormGroupModel) toApiRequest() *v1.FormGroup {
 		Type:          v1.FormGroupType(group.Type.ValueString()),
 		Label:         &label,
 		Info:          &info,
+		Subtitle:      modelListToStringSlice(group.Subtitle),
 		NestedDisplay: group.NestedDisplay.ValueBoolPointer(),
 		Items:         items,
 		Target:        group.Target.ValueStringPointer(),
@@ -463,6 +472,13 @@ func (group *CustomFormGroupModel) fromApiResponse(resp *v1.FormGroup) (diags di
 
 	group.ID = types.StringValue(resp.Id)
 	group.Type = types.StringValue(string(resp.Type))
+
+	if resp.Subtitle != nil {
+		group.Subtitle, diags = types.ListValue(types.StringType, stringSliceToValueList(resp.Subtitle))
+		if diags.HasError() {
+			return
+		}
+	}
 
 	if resp.Label != nil {
 		group.Label, diags = types.MapValue(types.StringType, stringMapToValueMap(*resp.Label))


### PR DESCRIPTION
Add new `subtitle` field for repeat groups, enabling dynamic computation and display of subtitles based on user-provided data. 